### PR TITLE
Update Babylon Lite GL v0.2.0 to v1.4.0

### DIFF
--- a/examples/babylon-lite-gl/cube/index.html
+++ b/examples/babylon-lite-gl/cube/index.html
@@ -8,7 +8,7 @@
   <script type="importmap">
   {
     "imports": {
-      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@0.2.0"
+      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@1.4.0"
     }
   }
   </script>

--- a/examples/babylon-lite-gl/square/index.html
+++ b/examples/babylon-lite-gl/square/index.html
@@ -7,7 +7,7 @@
   <script type="importmap">
   {
     "imports": {
-      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@0.2.0"
+      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@1.4.0"
     }
   }
   </script>

--- a/examples/babylon-lite-gl/teapot/index.html
+++ b/examples/babylon-lite-gl/teapot/index.html
@@ -8,7 +8,7 @@
   <script type="importmap">
   {
     "imports": {
-      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@0.2.0"
+      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@1.4.0"
     }
   }
   </script>

--- a/examples/babylon-lite-gl/texture/index.html
+++ b/examples/babylon-lite-gl/texture/index.html
@@ -8,7 +8,7 @@
   <script type="importmap">
   {
     "imports": {
-      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@0.2.0"
+      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@1.4.0"
     }
   }
   </script>

--- a/examples/babylon-lite-gl/triangle/index.html
+++ b/examples/babylon-lite-gl/triangle/index.html
@@ -7,7 +7,7 @@
   <script type="importmap">
   {
     "imports": {
-      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@0.2.0"
+      "@babylonjs/lite-gl": "https://esm.sh/@babylonjs/lite-gl@1.4.0"
     }
   }
   </script>


### PR DESCRIPTION
Bump the `@babylonjs/lite-gl` import map entry from `0.2.0` to `1.4.0` (current npm `latest`) across all five samples.

| sample | file |
|---|---|
| triangle | `examples/babylon-lite-gl/triangle/index.html` |
| square | `examples/babylon-lite-gl/square/index.html` |
| cube | `examples/babylon-lite-gl/cube/index.html` |
| texture | `examples/babylon-lite-gl/texture/index.html` |
| teapot | `examples/babylon-lite-gl/teapot/index.html` |

## API compatibility

Diffed the published `.d.ts` declarations of 0.2.0 and 1.4.0:

- **Removed in 1.4.0:** `GLPingPong`, `createPingPong`, `disposePingPong`, `resizePingPong` — none used by any sample.
- **Added in 1.4.0:** `GLStencilOpState`, `getAlphaToCoverage`, `getCurrentSampleCount`, `setAlphaToCoverage`, `setStencilOpSeparate`.
- All 16 functions the samples import keep identical signatures.

## Verification

Served the repo over HTTP and screenshotted each sample in headless Chrome with WebGL2 (ANGLE/SwiftShader). All five render as expected: blue triangle, gradient quad, red rotating cube, tree-frog textured cube, and the metal-textured teapot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)