### PR TITLE
Add a skill for running samples in a real browser

### DIFF
--- a/.claude/skills/run-webgl-sample/SKILL.md
+++ b/.claude/skills/run-webgl-sample/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: run-webgl-sample
+description: Launch any sample in this repo in a real browser and screenshot it to confirm it actually renders. Use when asked to run, open, verify, or screenshot a sample, when checking that a change or a library version bump still draws correctly, or when a sample is reported broken/blank. Covers all examples/<library>/<sample>/ directories.
+---
+
+# Running a WebGL sample from this repo
+
+This repo is a **pure static site** — no `package.json`, no build step, no
+dev server of its own. Every sample is `examples/<library>/<sample>/`
+containing `index.html` + `index.js` + `style.css`, sharing `libs/` and
+`assets/` at the repo root.
+
+## Quick start
+
+```bash
+scripts/shoot.sh <outdir> <library/sample> [library/sample ...]
+```
+
+From the repo root, e.g.:
+
+```bash
+.claude/skills/run-webgl-sample/scripts/shoot.sh /tmp/shots \
+  babylon-lite-gl/triangle babylon-lite-gl/teapot threejs/teapot
+```
+
+It serves the repo, screenshots each sample in headless Chrome with
+software WebGL2, writes `<outdir>/<library>-<sample>.png`, and stops the
+server again. Add `--console` as the first argument to also dump the
+page's console errors — do that when a frame comes out blank.
+
+Then **read the PNGs and look at them** — see "Judging the result" below.
+
+## Why a plain `open index.html` does not work
+
+- **`file://` fails.** Most samples use `<script type="module">` plus an
+  `importmap` pointing at esm.sh. Module loading over `file://` fails on
+  CORS and the page silently renders nothing. A static HTTP server is
+  mandatory — and it must serve the **repo root**, not the sample
+  directory, since samples reference `../../../libs/` and
+  `../../../assets/`.
+- **Headless Chrome has no GPU by default.** Without the ANGLE/SwiftShader
+  flags, `getContext("webgl2")` returns null and you screenshot a blank
+  canvas — which looks exactly like a broken sample.
+
+## What the script does, and why
+
+If you drive Chrome by hand instead of using the script, these are the
+parts that matter:
+
+- `--use-gl=angle --use-angle=swiftshader --enable-unsafe-swiftshader` —
+  software WebGL2. Chrome refuses SwiftShader for WebGL without the
+  `--enable-unsafe-swiftshader` opt-in; drop it and you get a blank canvas.
+- `--virtual-time-budget=8000` — samples gate their first draw on async
+  work: shader programs compile asynchronously (the babylon-lite-gl ones
+  poll `isEffectReady` before building the VAO), textures load over HTTP,
+  and animated samples need a few frames. A short budget screenshots an
+  empty canvas.
+- `--window-size=480,480` — canvases in this repo are `465x465`.
+- On Windows, `--screenshot=` needs a **native** path. MSYS/Git Bash does
+  not rewrite paths inside a `--flag=value` pair, so the script pipes it
+  through `cygpath -w`.
+- Stopping the server must be done **by listening port**, not by the pid
+  from `$!`. On Windows the `python3.exe` Store alias spawns a separate
+  real process, so killing the recorded pid leaves the server running and
+  the next run silently reuses a stale server.
+
+## Judging the result
+
+Read each PNG with the Read tool and **look at it**. A blank canvas is the
+standard failure mode and is indistinguishable from success unless you
+view the image — the script prints `OK` for any sample that produced a
+file, including a blank one. File size is a useful smoke signal (a solid
+frame compresses to ~1-2 KB) but not a substitute for viewing.
+
+Background color varies by sample — some clear to white, some to black
+(`examples/threejs/teapot` is black). Both are correct; a *blank* frame
+means no geometry, not a particular background. Animated samples (cube,
+texture, teapot) are mid-rotation at capture time, so the exact angle
+differs run to run — judge the shape and shading, not the orientation.
+
+Reference for what the babylon-lite-gl set should look like:
+
+| sample | expected |
+|---|---|
+| triangle | solid blue triangle on white |
+| square | red/green/blue/yellow interpolated gradient quad |
+| cube | solid red rotating cube |
+| texture | rotating cube mapped with the tree-frog photo |
+| teapot | Utah teapot with the gray `arroway.de_metal+structure` texture |
+
+## Diagnosing a blank frame
+
+Re-run with `--console`. Known causes, in rough order of likelihood:
+
+- **`raw.githubusercontent.com` import.** Several older samples import a
+  library straight from a raw GitHub URL. That host serves
+  `Content-Type: text/plain` with `X-Content-Type-Options: nosniff`, so
+  strict MIME checking refuses to execute it as a module and the page
+  renders nothing:
+
+  > Failed to load module script: Expected a JavaScript-or-Wasm module
+  > script but the server responded with a MIME type of "text/plain".
+
+  This breaks in **every** modern browser, not just headless —
+  `examples/ogl/cube` is a confirmed instance. It is a pre-existing repo
+  issue; do not attribute it to whatever you just changed. Fixing it means
+  repointing the import at a proper CDN (esm.sh / jsDelivr / unpkg).
+- **Missing SwiftShader flags**, if you are driving Chrome by hand.
+- **Budget too short** — raise `--virtual-time-budget`.
+- **A dead CDN version** in the `importmap`; the console shows a 404.
+
+## Verifying a library version bump
+
+When the change is a version bump in an `importmap` (e.g.
+`@babylonjs/lite-gl@0.2.0` → `@1.4.0`), diff the published type
+declarations *before* rendering — it tells you in seconds whether any API
+the sample uses was removed or changed shape, and it explains any
+breakage the screenshots reveal.
+
+```bash
+for v in 0.2.0 1.4.0; do
+  curl -sL "https://registry.npmjs.org/@babylonjs/lite-gl/-/lite-gl-$v.tgz" -o "lg-$v.tgz"
+  mkdir -p "v$v" && tar -xzf "lg-$v.tgz" -C "v$v"
+done
+```
+
+Then compare the `export declare function` signatures across every
+`*.d.ts` in `v<ver>/package/`, and intersect the removed/changed set with
+the names the samples actually import (the `import { ... } from "<pkg>"`
+list in each `index.js`). Only overlap matters — an upstream removal of
+something no sample imports is a non-event.
+
+Screenshots stay mandatory regardless: matching signatures do not prove
+matching runtime behavior.
+
+## Requirements
+
+- Chrome, Chromium, or Edge. Auto-detected on Windows/macOS/Linux;
+  override with `CHROME=/path/to/chrome`.
+- `python3`, `python`, or `npx` to serve. Override the port with
+  `PORT=9000`.

--- a/.claude/skills/run-webgl-sample/scripts/shoot.sh
+++ b/.claude/skills/run-webgl-sample/scripts/shoot.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Screenshot one or more samples from this repo in a real browser.
+#
+#   scripts/shoot.sh <outdir> <library/sample> [library/sample ...]
+#   scripts/shoot.sh --console <outdir> <library/sample>   # also dump page console errors
+#
+# Starts a static server on the repo root, drives headless Chrome with
+# software WebGL2, writes <outdir>/<library>-<sample>.png, then stops the
+# server. Reuses an already-running server on the same port if it finds one.
+set -euo pipefail
+
+PORT="${PORT:-8899}"
+CONSOLE=0
+if [ "${1:-}" = "--console" ]; then CONSOLE=1; shift; fi
+
+OUT="${1:?usage: shoot.sh [--console] <outdir> <library/sample>...}"; shift
+[ "$#" -gt 0 ] || { echo "no samples given" >&2; exit 2; }
+
+ROOT="$(git rev-parse --show-toplevel)"
+mkdir -p "$OUT"
+
+# Chrome must be a real Chromium build: Firefox/Safari can't take --screenshot.
+CHROME="${CHROME:-}"
+if [ -z "$CHROME" ]; then
+  for c in \
+    "/c/Program Files/Google/Chrome/Application/chrome.exe" \
+    "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe" \
+    "/c/Program Files/Microsoft/Edge/Application/msedge.exe" \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+    "/Applications/Chromium.app/Contents/MacOS/Chromium" \
+    google-chrome google-chrome-stable chromium chromium-browser
+  do
+    if [ -x "$c" ]; then CHROME="$c"; break; fi
+    if command -v "$c" > /dev/null 2>&1; then CHROME="$(command -v "$c")"; break; fi
+  done
+fi
+[ -n "$CHROME" ] || { echo "Chrome/Chromium not found; set CHROME=/path/to/chrome" >&2; exit 1; }
+
+# Kill by listening port, not by the pid we recorded. On Windows the pid
+# from $! is often a launcher that outlives nothing useful -- the
+# python3.exe Store alias, for one, spawns a separate real process, so
+# killing the recorded pid leaves the server running.
+kill_port() {
+  if command -v lsof > /dev/null 2>&1; then
+    lsof -ti "tcp:$1" 2>/dev/null | while read -r p; do kill "$p" 2>/dev/null || true; done
+  fi
+  if command -v taskkill > /dev/null 2>&1; then
+    netstat -ano 2>/dev/null | grep -i listening | grep ":$1 " | awk '{print $NF}' | sort -u |
+      while read -r p; do taskkill //F //T //PID "$p" > /dev/null 2>&1 || true; done
+  fi
+}
+
+started=0
+if ! curl -fsS -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then
+  if command -v python3 > /dev/null 2>&1; then SERVE=(python3 -m http.server "$PORT" --bind 127.0.0.1)
+  elif command -v python > /dev/null 2>&1; then SERVE=(python -m http.server "$PORT" --bind 127.0.0.1)
+  elif command -v npx > /dev/null 2>&1; then SERVE=(npx --yes http-server -p "$PORT" -a 127.0.0.1 -c-1)
+  else echo "need python3, python or npx to serve" >&2; exit 1; fi
+  ( cd "$ROOT" && "${SERVE[@]}" > /dev/null 2>&1 & echo $! > "$OUT/.server.pid" )
+  started=1
+  for _ in $(seq 40); do
+    curl -fsS -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null && break
+    sleep 0.25
+  done
+fi
+cleanup() {
+  if [ "$started" = 1 ]; then
+    [ -f "$OUT/.server.pid" ] && kill "$(cat "$OUT/.server.pid")" 2>/dev/null
+    kill_port "$PORT"
+    rm -f "$OUT/.server.pid"
+  fi
+}
+trap cleanup EXIT
+
+# On Windows, Chrome is a native binary and needs a native path for
+# --screenshot; MSYS does not rewrite it for us inside a --flag=value pair.
+winpath() { if command -v cygpath > /dev/null 2>&1; then cygpath -w "$1"; else printf '%s' "$1"; fi; }
+
+status=0
+for s in "$@"; do
+  name="${s//\//-}"
+  png="$OUT/$name.png"
+  url="http://127.0.0.1:$PORT/examples/$s/index.html"
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$url")"
+  if [ "$code" != "200" ]; then
+    echo "MISSING  $s (HTTP $code)"; status=1; continue
+  fi
+  logs=()
+  [ "$CONSOLE" = 1 ] && logs=(--enable-logging=stderr --log-level=0)
+  "$CHROME" --headless=new --disable-gpu-sandbox \
+    --use-gl=angle --use-angle=swiftshader --enable-unsafe-swiftshader \
+    --hide-scrollbars --window-size=480,480 --virtual-time-budget=8000 \
+    "${logs[@]}" --screenshot="$(winpath "$png")" "$url" 2> "$OUT/$name.log" || true
+  if [ -s "$png" ]; then
+    echo "OK       $s -> $png ($(wc -c < "$png" | tr -d ' ') bytes)"
+  else
+    echo "FAILED   $s (no image written)"; status=1
+  fi
+  if [ "$CONSOLE" = 1 ]; then
+    grep -E "CONSOLE|ERROR|Refused|MIME" "$OUT/$name.log" || echo "         (no console errors)"
+  fi
+done
+
+echo
+echo "Now LOOK at the PNGs. A blank frame is the standard failure mode and"
+echo "is indistinguishable from success unless you view the image."
+exit "$status"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings; CRLF breaks the shebang on
+# Linux/macOS with "bad interpreter: /usr/bin/env bash^M".
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Claude Code per-developer settings (permissions etc.); the shared
+# .claude/settings.json and .claude/skills/ are committed.
+.claude/settings.local.json


### PR DESCRIPTION
Adds a Claude Code project skill that launches any `examples/<library>/<sample>/` in headless Chrome and screenshots it, so verifying a change means looking at the rendered frame rather than assuming.

## Why

Every awkward part of doing this produces a **blank canvas**, which is indistinguishable from a genuinely broken sample:

- `file://` cannot load the importmap/module samples, and the server must serve the **repo root** because samples reference `../../../libs` and `../../../assets`
- headless Chrome needs `--enable-unsafe-swiftshader` to hand out a WebGL2 context at all
- the first draw is gated on async shader compilation and texture loads, so a short `--virtual-time-budget` captures an empty frame

## Contents

| file | purpose |
|---|---|
| `.claude/skills/run-webgl-sample/SKILL.md` | when to use it, why each flag matters, how to judge the output, how to diagnose a blank frame, and how to check an `importmap` version bump against the published `.d.ts` |
| `.claude/skills/run-webgl-sample/scripts/shoot.sh` | the runner |
| `.gitattributes` | keep `*.sh` at LF — CRLF breaks the shebang on Linux/macOS |
| `.gitignore` | `.claude/settings.local.json` is per-developer; the skill is shared |

```bash
.claude/skills/run-webgl-sample/scripts/shoot.sh /tmp/shots \
  babylon-lite-gl/triangle threejs/teapot
```

Chrome and the static server are auto-detected across Windows, macOS and Linux (`CHROME=` and `PORT=` override). Two Windows traps are handled in the script: `--screenshot=` needs a native path since MSYS does not rewrite paths inside a `--flag=value` pair, and the server must be stopped by **listening port** because the `python3.exe` Store alias spawns a separate real process that outlives the recorded pid.

## Pre-existing issue found while testing

`examples/ogl/cube` renders blank, unrelated to this PR. It imports from `raw.githubusercontent.com`, which serves `Content-Type: text/plain` with `X-Content-Type-Options: nosniff`, so strict MIME checking refuses to execute it as a module:

> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/plain".

This breaks in every modern browser, not just headless. Not fixed here — it needs the import repointed at a proper CDN. Happy to do that in a follow-up, and to sweep the other samples for the same pattern.

## Verification

Ran the script against `babylon-lite-gl` (all five), `threejs/teapot`, `webgl2/texture` and `ogl/cube`, and viewed every PNG. All render as expected except `ogl/cube` as described above. Also confirmed the 404 path reports `MISSING` with a non-zero exit, `--console` surfaces the page error, and the server is stopped afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)