### PR TITLE
Load OGL from a CDN via an import map, and fix a texture wrap typo

### DIFF
--- a/examples/ogl/cube/index.html
+++ b/examples/ogl/cube/index.html
@@ -3,6 +3,13 @@
 <head>
   <title>Testing Cube Using OGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "ogl": "https://esm.sh/ogl@1.0.11"
+    }
+  }
+  </script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/ogl/cube/index.js
+++ b/examples/ogl/cube/index.js
@@ -1,4 +1,4 @@
-import {Renderer, Geometry, Transform, Camera, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/1148a0941ce823dc6c342b3f54cce14cb6a14812/src/Core.js';
+import {Renderer, Geometry, Transform, Camera, Program, Color, Mesh} from 'ogl';
 
 {
     const renderer = new Renderer();

--- a/examples/ogl/primitive/index.html
+++ b/examples/ogl/primitive/index.html
@@ -3,6 +3,13 @@
 <head>
   <title>Testing Textured Cube Using OGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "ogl": "https://esm.sh/ogl@1.0.11"
+    }
+  }
+  </script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/ogl/primitive/index.js
+++ b/examples/ogl/primitive/index.js
@@ -21,8 +21,8 @@ import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh, Pl
     const scene = new Transform();
 
     const texture = new Texture(gl);
-    texture.wrapS = gl.REPEART;
-    texture.wrapT = gl.REPEART;
+    texture.wrapS = gl.REPEAT;
+    texture.wrapT = gl.REPEAT;
     const img = new Image();
 
     img.onload = () => texture.image = img;

--- a/examples/ogl/primitive/index.js
+++ b/examples/ogl/primitive/index.js
@@ -1,5 +1,4 @@
-import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/c9842ecd96e7de54397b1add70709e1efd8ebf4d/src/Core.js';
-import {Plane, Box, Sphere} from 'https://raw.githubusercontent.com/oframe/ogl/c9842ecd96e7de54397b1add70709e1efd8ebf4d/src/Extras.js';
+import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh, Plane, Box, Sphere} from 'ogl';
 
 {
     const renderer = new Renderer({dpr: 2});

--- a/examples/ogl/square/index.html
+++ b/examples/ogl/square/index.html
@@ -3,6 +3,13 @@
 <head>
   <title>Testing Square Using OGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "ogl": "https://esm.sh/ogl@1.0.11"
+    }
+  }
+  </script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/ogl/square/index.js
+++ b/examples/ogl/square/index.js
@@ -1,4 +1,4 @@
-import {Renderer, Geometry, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/1148a0941ce823dc6c342b3f54cce14cb6a14812/src/Core.js';
+import {Renderer, Geometry, Program, Color, Mesh} from 'ogl';
 
 {
     const renderer = new Renderer();

--- a/examples/ogl/teapot/index.html
+++ b/examples/ogl/teapot/index.html
@@ -4,6 +4,13 @@
   <title>Testing Teapot Using OGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
+  <script type="importmap">
+  {
+    "imports": {
+      "ogl": "https://esm.sh/ogl@1.0.11"
+    }
+  }
+  </script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/ogl/teapot/index.js
+++ b/examples/ogl/teapot/index.js
@@ -1,4 +1,4 @@
-import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/1148a0941ce823dc6c342b3f54cce14cb6a14812/src/Core.js';
+import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh} from 'ogl';
 
 let vertexPositions;
 let vertexNormals;

--- a/examples/ogl/teapot/index.js
+++ b/examples/ogl/teapot/index.js
@@ -32,8 +32,8 @@ $.getJSON("../../../assets/json/teapot.json", function (data) {
     const scene = new Transform();
 
     const texture = new Texture(gl);
-    texture.wrapS = gl.REPEART;
-    texture.wrapT = gl.REPEART;
+    texture.wrapS = gl.REPEAT;
+    texture.wrapT = gl.REPEAT;
     const img = new Image();
 
     img.onload = () => texture.image = img;

--- a/examples/ogl/texture/index.html
+++ b/examples/ogl/texture/index.html
@@ -3,6 +3,13 @@
 <head>
   <title>Testing Textured Cube Using OGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "ogl": "https://esm.sh/ogl@1.0.11"
+    }
+  }
+  </script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/ogl/texture/index.js
+++ b/examples/ogl/texture/index.js
@@ -21,8 +21,8 @@ import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh} fr
     const scene = new Transform();
 
     const texture = new Texture(gl);
-    texture.wrapS = gl.REPEART;
-    texture.wrapT = gl.REPEART;
+    texture.wrapS = gl.REPEAT;
+    texture.wrapT = gl.REPEAT;
     const img = new Image();
 
     img.onload = () => texture.image = img;

--- a/examples/ogl/texture/index.js
+++ b/examples/ogl/texture/index.js
@@ -1,4 +1,4 @@
-import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/1148a0941ce823dc6c342b3f54cce14cb6a14812/src/Core.js';
+import {Renderer, Geometry, Transform, Camera, Texture, Program, Color, Mesh} from 'ogl';
 
 {
     const renderer = new Renderer();

--- a/examples/ogl/triangle/index.html
+++ b/examples/ogl/triangle/index.html
@@ -3,6 +3,13 @@
 <head>
   <title>Testing Triangle Using OGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "ogl": "https://esm.sh/ogl@1.0.11"
+    }
+  }
+  </script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/ogl/triangle/index.js
+++ b/examples/ogl/triangle/index.js
@@ -1,4 +1,4 @@
-import {Renderer, Geometry, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/1148a0941ce823dc6c342b3f54cce14cb6a14812/src/Core.js';
+import {Renderer, Geometry, Program, Color, Mesh} from 'ogl';
 
 {
     const renderer = new Renderer();


### PR DESCRIPTION
## Problem

**All six OGL samples rendered nothing** — not just `cube`. They imported the library straight from `raw.githubusercontent.com`, which serves `Content-Type: text/plain` with `X-Content-Type-Options: nosniff`, so strict MIME type checking refuses to execute it as a module:

> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec.

This fails in **every modern browser**, not just headless. Confirmed by screenshotting all six on `master` — every one came out a blank canvas (identical 1722-byte PNGs).

## Commit 1 — load from a CDN via an import map

Point the imports at esm.sh, declared through an import map in `index.html` so `index.js` carries no version information — matching how the Babylon Lite GL samples are wired.

```html
  <script type="importmap">
  {
    "imports": {
      "ogl": "https://esm.sh/ogl@1.0.11"
    }
  }
  </script>
```

```diff
-import {Renderer, Geometry, Program, Color, Mesh} from 'https://raw.githubusercontent.com/oframe/ogl/1148a094.../src/Core.js';
+import {Renderer, Geometry, Program, Color, Mesh} from 'ogl';
```

The two pinned commits (`Core.js` at `1148a094`, and `Extras.js` at `c9842ecd` for `primitive`) both collapse into the single `ogl` entry point, since the package now re-exports Core, Extras and Math from `src/index.js`. That merges `primitive`'s two imports into one. `ogl@1.0.11` is the current npm `latest`.

## Commit 2 — fix the `gl.REPEART` typo

`texture`, `teapot` and `primitive` set the wrap mode with `gl.REPEART` instead of `gl.REPEAT`. The misspelled property is `undefined`, so ogl passed that straight to `texParameteri` and each sample logged:

```
WebGL: INVALID_ENUM: texParameter: invalid parameter
```

Non-fatal — the default `CLAMP_TO_EDGE` stayed in effect and the samples still drew — but the intent was clearly `REPEAT`. All three textures are power-of-two (frog 256x256, earth and the metal structure 1024x512), so `REPEAT` is valid for them even on WebGL1, where NPOT textures with a repeating wrap mode would render black.

## Verification

Screenshotted all six in headless Chrome with WebGL2 and viewed every frame:

| sample | before | after |
|---|---|---|
| triangle | blank | blue triangle |
| square | blank | RGBY gradient quad |
| cube | blank | vertex-colored rotating cube |
| texture | blank | tree-frog textured cube |
| teapot | blank | metal-textured teapot |
| primitive | blank | plane / box / sphere with the earth texture |

`triangle` and `square` now come out **pixel-identical** to the Babylon Lite GL equivalents, which is the intended result for this repo. After commit 2 the console is clean for all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)