### PR TITLE
Move the babylon-lite-gl shaders into index.html

### DIFF
--- a/examples/babylon-lite-gl/cube/index.html
+++ b/examples/babylon-lite-gl/cube/index.html
@@ -14,6 +14,28 @@
   </script>
 </head>
 <body>
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 position;
+in vec4 color;
+uniform mat4 worldViewProjection;
+out vec4 vColor;
+
+void main() {
+    vColor = color;
+    gl_Position = worldViewProjection * vec4(position, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+in vec4 vColor;
+out vec4 glFragColor;
+
+void main() {
+    glFragColor = vColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/babylon-lite-gl/cube/index.js
+++ b/examples/babylon-lite-gl/cube/index.js
@@ -9,25 +9,8 @@ const canvas = document.getElementById("c");
 const engine = createGLEngine(canvas, { alpha: false, depth: true });
 setDepthState(engine, { test: true, write: true });
 
-const vertexSource = `#version 300 es
-in vec3 position;
-in vec4 color;
-uniform mat4 worldViewProjection;
-out vec4 vColor;
-
-void main() {
-    vColor = color;
-    gl_Position = worldViewProjection * vec4(position, 1.0);
-}`;
-
-const fragmentSource = `#version 300 es
-precision highp float;
-in vec4 vColor;
-out vec4 glFragColor;
-
-void main() {
-    glFragColor = vColor;
-}`;
+const vertexSource = document.getElementById("vs").textContent;
+const fragmentSource = document.getElementById("fs").textContent;
 
 const effect = createEffect(engine, {
   name: "cube",

--- a/examples/babylon-lite-gl/square/index.html
+++ b/examples/babylon-lite-gl/square/index.html
@@ -13,6 +13,27 @@
   </script>
 </head>
 <body>
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 position;
+in vec4 color;
+out vec4 vColor;
+
+void main() {
+    vColor = color;
+    gl_Position = vec4(position, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+in vec4 vColor;
+out vec4 glFragColor;
+
+void main() {
+    glFragColor = vColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/babylon-lite-gl/square/index.js
+++ b/examples/babylon-lite-gl/square/index.js
@@ -8,24 +8,8 @@ import {
 const canvas = document.getElementById("c");
 const engine = createGLEngine(canvas, { alpha: false });
 
-const vertexSource = `#version 300 es
-in vec3 position;
-in vec4 color;
-out vec4 vColor;
-
-void main() {
-    vColor = color;
-    gl_Position = vec4(position, 1.0);
-}`;
-
-const fragmentSource = `#version 300 es
-precision highp float;
-in vec4 vColor;
-out vec4 glFragColor;
-
-void main() {
-    glFragColor = vColor;
-}`;
+const vertexSource = document.getElementById("vs").textContent;
+const fragmentSource = document.getElementById("fs").textContent;
 
 const effect = createEffect(engine, {
   name: "square",

--- a/examples/babylon-lite-gl/teapot/index.html
+++ b/examples/babylon-lite-gl/teapot/index.html
@@ -14,6 +14,38 @@
   </script>
 </head>
 <body>
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 position;
+in vec3 normal;
+in vec2 uv;
+uniform mat4 worldViewProjection;
+uniform mat4 world;
+out vec3 vNormal;
+out vec2 vTextureCoord;
+
+void main() {
+    vNormal = mat3(world) * normal;
+    vTextureCoord = uv;
+    gl_Position = worldViewProjection * vec4(position, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+uniform sampler2D texture_;
+in vec3 vNormal;
+in vec2 vTextureCoord;
+out vec4 glFragColor;
+
+void main() {
+    vec3 lightDir = normalize(vec3(1.0, 0.0, 1.0));
+    float diffuse = max(dot(normalize(vNormal), lightDir), 0.0);
+    float lighting = 0.3 + 0.7 * diffuse;
+    vec4 baseColor = texture(texture_, vTextureCoord);
+    glFragColor = vec4(baseColor.rgb * lighting, baseColor.a);
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/babylon-lite-gl/teapot/index.js
+++ b/examples/babylon-lite-gl/teapot/index.js
@@ -10,35 +10,8 @@ const canvas = document.getElementById("c");
 const engine = createGLEngine(canvas, { alpha: false, depth: true });
 setDepthState(engine, { test: true, write: true });
 
-const vertexSource = `#version 300 es
-in vec3 position;
-in vec3 normal;
-in vec2 uv;
-uniform mat4 worldViewProjection;
-uniform mat4 world;
-out vec3 vNormal;
-out vec2 vTextureCoord;
-
-void main() {
-    vNormal = mat3(world) * normal;
-    vTextureCoord = uv;
-    gl_Position = worldViewProjection * vec4(position, 1.0);
-}`;
-
-const fragmentSource = `#version 300 es
-precision highp float;
-uniform sampler2D texture_;
-in vec3 vNormal;
-in vec2 vTextureCoord;
-out vec4 glFragColor;
-
-void main() {
-    vec3 lightDir = normalize(vec3(1.0, 0.0, 1.0));
-    float diffuse = max(dot(normalize(vNormal), lightDir), 0.0);
-    float lighting = 0.3 + 0.7 * diffuse;
-    vec4 baseColor = texture(texture_, vTextureCoord);
-    glFragColor = vec4(baseColor.rgb * lighting, baseColor.a);
-}`;
+const vertexSource = document.getElementById("vs").textContent;
+const fragmentSource = document.getElementById("fs").textContent;
 
 const effect = createEffect(engine, {
   name: "teapot",

--- a/examples/babylon-lite-gl/texture/index.html
+++ b/examples/babylon-lite-gl/texture/index.html
@@ -14,6 +14,29 @@
   </script>
 </head>
 <body>
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 position;
+in vec2 uv;
+uniform mat4 worldViewProjection;
+out vec2 vTextureCoord;
+
+void main() {
+    vTextureCoord = uv;
+    gl_Position = worldViewProjection * vec4(position, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+uniform sampler2D texture_;
+in vec2 vTextureCoord;
+out vec4 glFragColor;
+
+void main() {
+    glFragColor = texture(texture_, vTextureCoord);
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/babylon-lite-gl/texture/index.js
+++ b/examples/babylon-lite-gl/texture/index.js
@@ -10,26 +10,8 @@ const canvas = document.getElementById("c");
 const engine = createGLEngine(canvas, { alpha: false, depth: true });
 setDepthState(engine, { test: true, write: true });
 
-const vertexSource = `#version 300 es
-in vec3 position;
-in vec2 uv;
-uniform mat4 worldViewProjection;
-out vec2 vTextureCoord;
-
-void main() {
-    vTextureCoord = uv;
-    gl_Position = worldViewProjection * vec4(position, 1.0);
-}`;
-
-const fragmentSource = `#version 300 es
-precision highp float;
-uniform sampler2D texture_;
-in vec2 vTextureCoord;
-out vec4 glFragColor;
-
-void main() {
-    glFragColor = texture(texture_, vTextureCoord);
-}`;
+const vertexSource = document.getElementById("vs").textContent;
+const fragmentSource = document.getElementById("fs").textContent;
 
 const effect = createEffect(engine, {
   name: "texture",

--- a/examples/babylon-lite-gl/triangle/index.html
+++ b/examples/babylon-lite-gl/triangle/index.html
@@ -13,6 +13,23 @@
   </script>
 </head>
 <body>
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 position;
+
+void main() {
+    gl_Position = vec4(position, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+out vec4 glFragColor;
+
+void main() {
+    glFragColor = vec4(0.0, 0.0, 1.0, 1.0);
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/babylon-lite-gl/triangle/index.js
+++ b/examples/babylon-lite-gl/triangle/index.js
@@ -8,20 +8,8 @@ import {
 const canvas = document.getElementById("c");
 const engine = createGLEngine(canvas, { alpha: false });
 
-const vertexSource = `#version 300 es
-in vec3 position;
-
-void main() {
-    gl_Position = vec4(position, 1.0);
-}`;
-
-const fragmentSource = `#version 300 es
-precision highp float;
-out vec4 glFragColor;
-
-void main() {
-    glFragColor = vec4(0.0, 0.0, 1.0, 1.0);
-}`;
+const vertexSource = document.getElementById("vs").textContent;
+const fragmentSource = document.getElementById("fs").textContent;
 
 const effect = createEffect(engine, {
   name: "triangle",


### PR DESCRIPTION
## Summary

The `examples/webgl2/` samples keep their GLSL in `<script id="vs">` / `<script id="fs">` tags inside `index.html`. The `examples/babylon-lite-gl/` samples had the same shaders embedded as template literals in `index.js`, which made the two sets awkward to compare. This moves all five babylon-lite-gl shaders into `index.html` so the shader code sits in the same place in both directories.

`index.js` now reads them the same way the webgl2 samples do:

```js
const vertexSource = document.getElementById("vs").textContent;
const fragmentSource = document.getElementById("fs").textContent;
```

The `examples/ogl/` samples already combine this pattern with an ES module + importmap, so no new mechanism is involved: `type="x-shader/..."` scripts are never executed, and `type="module"` is deferred until after the DOM is parsed, so `getElementById` resolves.

The GLSL itself is unchanged — `glFragColor`, `precision highp float`, and the babylon-lite-gl attribute/uniform names are kept as-is.

## Samples changed

`triangle`, `square`, `cube`, `texture`, `teapot`

## Test plan

All five samples were rendered in headless Chrome (ANGLE/SwiftShader, WebGL2) and screenshotted after the change:

- triangle — solid blue triangle
- square — red/green/blue/yellow interpolated quad
- cube — solid red rotating cube
- texture — rotating cube with the tree-frog texture
- teapot — Utah teapot with the metal-structure texture

All render as they did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)