### PR TITLE
Load the raw.githubusercontent libraries from jsDelivr

### DIFF
--- a/examples/claygl/cube/index.html
+++ b/examples/claygl/cube/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Cube Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
 </head>
 <body>
 <script type="x-shader/x-vertex" id="vs">

--- a/examples/claygl/primitive/index.html
+++ b/examples/claygl/primitive/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Primitive Types Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
 </head>
 <body>
 <div id="viewport"></div>

--- a/examples/claygl/quaternion/index.html
+++ b/examples/claygl/quaternion/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Primitive Types Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
 </head>
 <body>
 <div id="viewport"></div>

--- a/examples/claygl/square/index.html
+++ b/examples/claygl/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
 </head>
 <body>
 <script type="x-shader/x-vertex" id="vs">

--- a/examples/claygl/teapot/index.html
+++ b/examples/claygl/teapot/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Teapot Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/claygl/texture/index.html
+++ b/examples/claygl/texture/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
 </head>
 <body>
 <script type="x-shader/x-vertex" id="vs">

--- a/examples/claygl/triangle/index.html
+++ b/examples/claygl/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using ClayGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/pissang/claygl/b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/pissang/claygl@b157bb50cf8c725fa20f90ebb55481352777f0a7/dist/claygl.js"></script>
 </head>
 <body>
 <div id="viewport"></div>

--- a/examples/glcubic/cube/index.html
+++ b/examples/glcubic/cube/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Cube Using glCubic.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/doxas/glcubic.js/f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/doxas/glcubic.js@f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/glcubic/square/index.html
+++ b/examples/glcubic/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using glCubic.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/doxas/glcubic.js/f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/doxas/glcubic.js@f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/glcubic/teapot/index.html
+++ b/examples/glcubic/teapot/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Teapot Using glCubic.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/doxas/glcubic.js/f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/doxas/glcubic.js@f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/glcubic/texture/index.html
+++ b/examples/glcubic/texture/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using glCubic.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/doxas/glcubic.js/f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/doxas/glcubic.js@f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/glcubic/triangle/index.html
+++ b/examples/glcubic/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using glCubic.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/doxas/glcubic.js/f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/doxas/glcubic.js@f54ec385d2aa74a76deacd7be4d96253bfbaeefe/build/js/glcubic.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/gltips/cube/index.html
+++ b/examples/gltips/cube/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Cube Using glTips.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/emadurandal/glTips/155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/emadurandal/glTips@155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
   <script src="../../../libs/gl-matrix.js"></script>
 </head>
 <body>

--- a/examples/gltips/square/index.html
+++ b/examples/gltips/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using glTips.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/emadurandal/glTips/155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/emadurandal/glTips@155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/gltips/teapot/index.html
+++ b/examples/gltips/teapot/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Teapot Using glTips.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/emadurandal/glTips/155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/emadurandal/glTips@155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
   <script src="../../../libs/gl-matrix.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>

--- a/examples/gltips/texture/index.html
+++ b/examples/gltips/texture/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using glTips.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/emadurandal/glTips/155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/emadurandal/glTips@155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
   <script src="../../../libs/gl-matrix.js"></script>
 </head>
 <body>

--- a/examples/gltips/triangle/index.html
+++ b/examples/gltips/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using glTips.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/emadurandal/glTips/155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/emadurandal/glTips@155489f3b95947ad748db3a8b86977c7cd2ba026/glTips.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/lightgl/cube/index.html
+++ b/examples/lightgl/cube/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Cube Using lightgl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/evanw/lightgl.js/f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/evanw/lightgl.js@f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/lightgl/primitive/index.html
+++ b/examples/lightgl/primitive/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Primitive Types Using lightgl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/evanw/lightgl.js/f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/evanw/lightgl.js@f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/lightgl/square/index.html
+++ b/examples/lightgl/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using lightgl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/evanw/lightgl.js/f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/evanw/lightgl.js@f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/lightgl/teapot/index.html
+++ b/examples/lightgl/teapot/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>[WIP] Testing Teapot Using lightgl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/evanw/lightgl.js/f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/evanw/lightgl.js@f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/lightgl/texture/index.html
+++ b/examples/lightgl/texture/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using lightgl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/evanw/lightgl.js/f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/evanw/lightgl.js@f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/lightgl/triangle/index.html
+++ b/examples/lightgl/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using lightgl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/evanw/lightgl.js/f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/evanw/lightgl.js@f868b2e6d3d04981197d74cb0de4e99626d87091/lightgl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/litegl/cube/index.html
+++ b/examples/litegl/cube/index.html
@@ -4,7 +4,7 @@
   <title>Testing Cube Using litegl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="../../../libs/gl-matrix.js"></script>
-  <script src="https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jagenjo/litegl.js@3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/litegl/primitive/index.html
+++ b/examples/litegl/primitive/index.html
@@ -4,7 +4,7 @@
   <title>Testing Primitive Types Using litegl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="../../../libs/gl-matrix.js"></script>
-  <script src="https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jagenjo/litegl.js@3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/litegl/square/index.html
+++ b/examples/litegl/square/index.html
@@ -4,7 +4,7 @@
   <title>Testing Square Using litegl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="../../../libs/gl-matrix.js"></script>
-  <script src="https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jagenjo/litegl.js@3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/litegl/teapot/index.html
+++ b/examples/litegl/teapot/index.html
@@ -4,7 +4,7 @@
   <title>Testing Teapot Using litegl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="../../../libs/gl-matrix.js"></script>
-  <script src="https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jagenjo/litegl.js@3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/litegl/texture/index.html
+++ b/examples/litegl/texture/index.html
@@ -4,7 +4,7 @@
   <title>Testing Textured Cube Using litegl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="../../../libs/gl-matrix.js"></script>
-  <script src="https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jagenjo/litegl.js@3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/litegl/triangle/index.html
+++ b/examples/litegl/triangle/index.html
@@ -4,7 +4,7 @@
   <title>Testing Triangle Using litegl.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="../../../libs/gl-matrix.js"></script>
-  <script src="https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jagenjo/litegl.js@3d2c29cbbb8131eff07cd1c36456f69cb1b2cbf0/build/litegl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/picogl/cube/index.html
+++ b/examples/picogl/cube/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Cube Using PicoGL.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/tsherif/picogl.js/0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/tsherif/picogl.js@0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
   <script src="../../../libs/gl-matrix.js"></script>
 </head>
 <body>

--- a/examples/picogl/square/index.html
+++ b/examples/picogl/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using PicoGL.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/tsherif/picogl.js/0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/tsherif/picogl.js@0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/picogl/teapot/index.html
+++ b/examples/picogl/teapot/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Teapot Using PicoGL.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/tsherif/picogl.js/0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/tsherif/picogl.js@0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
   <script src="../../../libs/gl-matrix.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>

--- a/examples/picogl/texture/index.html
+++ b/examples/picogl/texture/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using PicoGL.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/tsherif/picogl.js/0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/tsherif/picogl.js@0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
   <script src="../../../libs/gl-matrix.js"></script>
 </head>
 <body>

--- a/examples/picogl/triangle/index.html
+++ b/examples/picogl/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using PicoGL.js</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/tsherif/picogl.js/0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/tsherif/picogl.js@0c0e9c014c770f4fb872c8095a543af0d5e38a33/build/picogl.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/wwg/cube/index.html
+++ b/examples/wwg/cube/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Testing Cube Using WWG</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
 </head>
 <body>
 <script id="vshader" type="x-shader/x-vertex">

--- a/examples/wwg/primitive/index.html
+++ b/examples/wwg/primitive/index.html
@@ -3,9 +3,9 @@
 <head>
   <title>Testing Textured Cube Using WWG</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWModel.js"></script>
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWModel.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
 </head>
 <body>
 <script id="vshader" type="x-shader/x-vertex">

--- a/examples/wwg/square/index.html
+++ b/examples/wwg/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using WWG</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
 </head>
 <body>
 <script id="vshader" type="x-shader/x-vertex">

--- a/examples/wwg/teapot/index.html
+++ b/examples/wwg/teapot/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Testing Teapot Using WWG</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/wwg/texture/index.html
+++ b/examples/wwg/texture/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Testing Textured Cube Using WWG</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/CanvasMatrix.js"></script>
 </head>
 <body>
 <script id="vshader" type="x-shader/x-vertex">

--- a/examples/wwg/triangle/index.html
+++ b/examples/wwg/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using WWG</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/wakufactory/wwg/482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/wakufactory/wwg@482a0e928781fd27bbd2e1173476f54df9bf1dda/js/WWG.js"></script>
 </head>
 <body>
 <script id="vshader" type="x-shader/x-vertex">

--- a/examples/xenogl/cube/index.html
+++ b/examples/xenogl/cube/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Testing Cube Using XenoGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/kotofurumiya/xenogl/8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
-  <script src="https://raw.githubusercontent.com/kotofurumiya/matrixgl/42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/xenogl@8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/matrixgl@42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">#version 300 es

--- a/examples/xenogl/quaternion/index.html
+++ b/examples/xenogl/quaternion/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>Testing quaternion rotation using XenoGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/kotofurumiya/xenogl/8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
-  <script src="https://raw.githubusercontent.com/kotofurumiya/matrixgl/42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/xenogl@8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/matrixgl@42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">#version 300 es

--- a/examples/xenogl/square/index.html
+++ b/examples/xenogl/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using XenoGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/kotofurumiya/xenogl/8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/xenogl@8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">#version 300 es

--- a/examples/xenogl/teapot/index.html
+++ b/examples/xenogl/teapot/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Testing Teapot Using XenoGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/kotofurumiya/xenogl/8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
-  <script src="https://raw.githubusercontent.com/kotofurumiya/matrixgl/42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/xenogl@8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/matrixgl@42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/xenogl/texture/index.html
+++ b/examples/xenogl/texture/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Testing Textured Cube Using XenoGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/kotofurumiya/xenogl/8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
-  <script src="https://raw.githubusercontent.com/kotofurumiya/matrixgl/42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/xenogl@8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/matrixgl@42f8c89c6c6d8be8ab90970b22675c9d97064cb3/build/matrixgl.min.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">#version 300 es

--- a/examples/xenogl/triangle/index.html
+++ b/examples/xenogl/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using XenoGL</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/kotofurumiya/xenogl/8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/kotofurumiya/xenogl@8ab6a66fdb585c2d6a3c207d4433e7097e80982c/build/xenogl.min.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">#version 300 es

--- a/examples/zen-3d/cube/index.html
+++ b/examples/zen-3d/cube/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Cube Using zen-3d</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/shawn0326/zen-3d/51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/shawn0326/zen-3d@51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/zen-3d/square/index.html
+++ b/examples/zen-3d/square/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Square Using zen-3d</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/shawn0326/zen-3d/51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/shawn0326/zen-3d@51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/zen-3d/teapot/index.html
+++ b/examples/zen-3d/teapot/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using zen-3d</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/shawn0326/zen-3d/51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/shawn0326/zen-3d@51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
   <script src="//code.jquery.com/jquery-3.4.0.js"></script>
 </head>
 <body>

--- a/examples/zen-3d/texture/index.html
+++ b/examples/zen-3d/texture/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Textured Cube Using zen-3d</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/shawn0326/zen-3d/51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/shawn0326/zen-3d@51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">

--- a/examples/zen-3d/triangle/index.html
+++ b/examples/zen-3d/triangle/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Testing Triangle Using zen-3d</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://raw.githubusercontent.com/shawn0326/zen-3d/51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/shawn0326/zen-3d@51dc33e11aaf6defdaf258fc41ed1997f22a7628/build/zen3d.js"></script>
 </head>
 <body>
 <script id="vs" type="x-shader/x-vertex">


### PR DESCRIPTION
## Problem

`raw.githubusercontent.com` serves JavaScript as `application/octet-stream` together with `X-Content-Type-Options: nosniff`, so browsers refuse to execute it:

```
Refused to execute script from
'https://raw.githubusercontent.com/jagenjo/litegl.js/3d2c29cb.../build/litegl.js'
because its MIME type ('application/octet-stream') is not executable,
and strict MIME type checking is enabled.

Uncaught ReferenceError: GL is not defined
```

Every sample that loads its library from a raw GitHub URL is blank as a result.

## Fix

Point the `<script src>` tags at jsDelivr's GitHub CDN, keeping the same pinned commit in every URL:

```
https://raw.githubusercontent.com/<user>/<repo>/<commit>/<path>
https://cdn.jsdelivr.net/gh/<user>/<repo>@<commit>/<path>
```

The served bytes are unchanged — all twelve files were compared against the raw versions by SHA-256 and are identical — and jsDelivr returns `application/javascript`. No sample code was touched.

| library | samples |
|---|---|
| claygl | 7 |
| lightgl.js | 6 |
| litegl.js | 6 |
| xenogl (+ matrixgl) | 6 |
| wwg (+ CanvasMatrix, WWModel) | 6 |
| glcubic.js | 5 |
| glTips | 5 |
| picogl.js | 5 |
| zen-3d | 5 |

51 files, 60 URLs.

## Out of scope

The `raw.githubusercontent.com` references remaining in `.js` files (glTF models, skybox textures, `Teapot.json`) are loaded via `fetch` / `<img>`, which are not subject to the executable-MIME check, and still work.

## Test plan

All 51 affected samples were rendered in headless Chrome (ANGLE/SwiftShader, WebGL2) and screenshotted.

- **45 render correctly** — triangles, gradient quads, rotating cubes, textured cubes, teapots, primitive/quaternion scenes.
- **6 captured blank** — `glcubic/{triangle,square}`, `picogl/{triangle,square}`, `wwg/{triangle,square}`. This is a headless screenshot artifact, not a regression:
  - no console errors; the libraries load (glcubic prints its `0.2.2` version banner, wwg logs its success path)
  - these six draw exactly once at load with no `requestAnimationFrame` loop and no `preserveDrawingBuffer`, so the drawing buffer is gone by capture time
  - re-shot from temporary copies with nothing added but a redraw loop, all six render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)